### PR TITLE
INTLY-5811 Sanitize uppercase letters from resource name

### DIFF
--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"unicode"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -63,9 +64,9 @@ func SanitizeResourceName(name string) string {
 			continue
 		}
 
-		// Uppercase letters
+		// Uppercase letters are transformed to lowercase
 		if ascii >= 65 && ascii <= 90 {
-			sb.WriteRune(char)
+			sb.WriteRune(unicode.ToLower(char))
 			continue
 		}
 

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -66,3 +66,17 @@ func TestUtil_Test_GetServiceEnvVar(t *testing.T) {
 	assert.Equal(t, GetServiceEnvVar("SERVICE_HOST"), "KEYCLOAK_POSTGRESQL_SERVICE_HOST")
 	assert.Equal(t, GetServiceEnvVar("SERVICE_PORT"), "KEYCLOAK_POSTGRESQL_SERVICE_PORT")
 }
+
+func TestUtil_SanitizeResourceName(t *testing.T) {
+	expected := map[string]string{
+		// Allowed characters
+		"test123-_.": "test123--.",
+		// Mixed of allowed characters and disallowed characters
+		"testTEST[(/%^&*,)]123-_.": "testtest123--.",
+	}
+
+	for input, output := range expected {
+		actual := SanitizeResourceName(input)
+		assert.Equal(t, output, actual)
+	}
+}


### PR DESCRIPTION
Cherry picked from upstream.

* [Integreatly JIRA](https://issues.redhat.com/browse/INTLY-5811)
* [Keycloak JIRA](https://issues.redhat.com/browse/KEYCLOAK-13158)
* [Upstream PR (merged)](https://github.com/keycloak/keycloak-operator/pull/151)