### PR TITLE
optimize readiness and liveness checks

### DIFF
--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -15,8 +15,9 @@ import (
 const (
 	LivenessProbeInitialDelay  = 30
 	ReadinessProbeInitialDelay = 40
-	//10s (cli) + 10s (curl) + 2s (just in case)
-	ProbeTimeoutSeconds = 22
+	//10s (curl) + 10s (curl) + 2s (just in case)
+	ProbeTimeoutSeconds         = 45
+	ProbeTimeBetweenRunsSeconds = 30
 )
 
 func GetServiceEnvVar(suffix string) string {
@@ -314,6 +315,9 @@ func livenessProbe() *v1.Probe {
 	return &v1.Probe{
 		InitialDelaySeconds: LivenessProbeInitialDelay,
 		TimeoutSeconds:      ProbeTimeoutSeconds,
+		PeriodSeconds:       ProbeTimeBetweenRunsSeconds,
+		SuccessThreshold:    1,
+		FailureThreshold:    5,
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
 				Command: []string{
@@ -330,6 +334,9 @@ func readinessProbe() *v1.Probe {
 	return &v1.Probe{
 		InitialDelaySeconds: ReadinessProbeInitialDelay,
 		TimeoutSeconds:      ProbeTimeoutSeconds,
+		PeriodSeconds:       ProbeTimeBetweenRunsSeconds,
+		SuccessThreshold:    1,
+		FailureThreshold:    5,
 		Handler: v1.Handler{
 			Exec: &v1.ExecAction{
 				Command: []string{


### PR DESCRIPTION
I'm having constant issues with Keycloak on PDS clusters, the container does not become ready and gets killed after a while ending up in a crash loop.

This PR tweaks the timeoutes of the liveness and readiness checks and also updates them to the latest scripts from upstream.